### PR TITLE
Fix for preRender issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It loads the element on the server by default supporting Search Engine Optimizat
 
 ```html
   <div
-    preRender="false"
+    [preRender]="false"
     (deferLoad)="showMyElement=true">
     <my-element
        *ngIf=showMyElement>

--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -31,7 +31,7 @@ export class DeferLoadDirective implements AfterViewInit, OnDestroy {
                 this.addScrollListeners();
             }
         } else {
-            if (this.preRender) {
+            if (this.preRender === true) {
                 this.load();
             }
         }


### PR DESCRIPTION
I fixed an issue where the component would be loaded when preRender was set to the string "false" instead of the boolean false.

I updated the readme accordingly as it didn't contain the square bracket notation that will evaluate the value.