### PR TITLE
Update check for IntersectionObserverEntry

### DIFF
--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -75,7 +75,7 @@ export class DeferLoadDirective implements AfterViewInit, OnDestroy {
     private checkIfIntersecting (entry: IntersectionObserverEntry) {
         // For Samsung native browser, IO has been partially implemented where by the
         // callback fires, but entry object is empty. We will check manually.
-        if (entry && Object.keys(entry).length) {
+        if (entry && entry.time) {
             return (<any>entry).isIntersecting && entry.target === this._element.nativeElement;
         }
         return this.isVisible();


### PR DESCRIPTION
The Object.keys(entry).length call always returned `0` in Chrome. This created problems when `(deferLoad)` was assigned to elements that also had `display:none`.