### PR TITLE
Feature universal fix and fallback optout

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you do not want to allow this fallback, and would prefer the browser to just 
 
 ```html
   <div
-    [preRender]="false"
+    [fallbackEnabled]="false"
     (deferLoad)="showMyElement=true">
     <my-element
        *ngIf=showMyElement>

--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ It loads the element on the server by default supporting Search Engine Optimizat
 </div>
 ```
 
+## Fall back support
+
+`ng-defer-load` supports a fall back in browsers that do not support the IntersectionObserver API. This uses the scroll position and the element's offset. This is enabled by default.
+
+If you do not want to allow this fallback, and would prefer the browser to just render the element regardless, you can set `fallbackEnabled` to false on the element as below:
+
+```html
+  <div
+    [preRender]="false"
+    (deferLoad)="showMyElement=true">
+    <my-element
+       *ngIf=showMyElement>
+      ...
+    </my-element>
+</div>
+```
+
 ## Demo
 
 Demo of *ng-defer-load* in use is available [here](https://stackblitz.com/edit/angular-defer-load).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trademe/ng-defer-load",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -761,12 +761,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -781,17 +783,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -908,7 +913,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -920,6 +926,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -934,6 +941,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -941,12 +949,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -965,6 +975,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1045,7 +1056,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1057,6 +1069,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1178,6 +1191,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trademe/ng-defer-load",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Angular directive to load elements lazily",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trademe/ng-defer-load",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.0-beta.3",
   "description": "Angular directive to load elements lazily",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trademe/ng-defer-load",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.0",
   "description": "Angular directive to load elements lazily",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -1,14 +1,15 @@
-import { isPlatformBrowser } from '@angular/common';
-import { AfterViewInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, Output, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { AfterViewInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
 @Directive({
     selector: '[deferLoad]'
 })
-export class DeferLoadDirective implements AfterViewInit, OnDestroy {
+export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
 
     @Input() public preRender: boolean = true;
+    @Input() public fallbackEnabled: boolean = true;
     @Output() public deferLoad: EventEmitter<any> = new EventEmitter();
 
     private _intersectionObserver?: IntersectionObserver;
@@ -20,6 +21,12 @@ export class DeferLoadDirective implements AfterViewInit, OnDestroy {
         @Inject(PLATFORM_ID) private platformId: Object
     ) { }
 
+    public ngOnInit () {
+        if (isPlatformServer(this.platformId) && this.preRender === true) {
+            this.load();
+        }
+    }
+
     public ngAfterViewInit () {
         if (isPlatformBrowser(this.platformId)) {
             if (this.hasCompatibleBrowser()) {
@@ -28,11 +35,11 @@ export class DeferLoadDirective implements AfterViewInit, OnDestroy {
                     this._intersectionObserver.observe(<Element>(this._element.nativeElement));
                 }
             } else {
-                this.addScrollListeners();
-            }
-        } else {
-            if (this.preRender === true) {
-                this.load();
+                if (this.fallbackEnabled) {
+                    this.addScrollListeners();
+                } else {
+                    this.load();
+                }
             }
         }
     }

--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -1,12 +1,12 @@
-import { isPlatformBrowser, isPlatformServer } from '@angular/common';
-import { AfterViewInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
 @Directive({
     selector: '[deferLoad]'
 })
-export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
+export class DeferLoadDirective implements OnInit, OnDestroy {
 
     @Input() public preRender: boolean = true;
     @Input() public fallbackEnabled: boolean = true;
@@ -24,11 +24,7 @@ export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
     public ngOnInit () {
         if (isPlatformServer(this.platformId) && this.preRender === true) {
             this.load();
-        }
-    }
-
-    public ngAfterViewInit () {
-        if (isPlatformBrowser(this.platformId)) {
+        } else {
             if (this.hasCompatibleBrowser()) {
                 this.registerIntersectionObserver();
                 if (this._intersectionObserver && this._element.nativeElement) {

--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
-import { Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -22,7 +22,8 @@ export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
     ) { }
 
     public ngOnInit () {
-        if (isPlatformServer(this.platformId) && this.preRender === true) {
+        if ((isPlatformServer(this.platformId) && this.preRender === true) ||
+            (isPlatformBrowser(this.platformId) && this.fallbackEnabled === false && !this.hasCompatibleBrowser())) {
             this.load();
         }
     }
@@ -34,12 +35,8 @@ export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
                 if (this._intersectionObserver && this._element.nativeElement) {
                     this._intersectionObserver.observe(<Element>(this._element.nativeElement));
                 }
-            } else {
-                if (this.fallbackEnabled === true) {
-                    this.addScrollListeners();
-                } else {
-                    this.load();
-                }
+            } else if (this.fallbackEnabled === true) {
+                this.addScrollListeners();
             }
         }
     }

--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -1,12 +1,12 @@
-import { isPlatformServer } from '@angular/common';
-import { Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { Directive, ElementRef, EventEmitter, Inject, Input, NgZone, OnDestroy, OnInit, Output, PLATFORM_ID, AfterViewInit } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
 @Directive({
     selector: '[deferLoad]'
 })
-export class DeferLoadDirective implements OnInit, OnDestroy {
+export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
 
     @Input() public preRender: boolean = true;
     @Input() public fallbackEnabled: boolean = true;
@@ -24,14 +24,18 @@ export class DeferLoadDirective implements OnInit, OnDestroy {
     public ngOnInit () {
         if (isPlatformServer(this.platformId) && this.preRender === true) {
             this.load();
-        } else {
+        }
+    }
+
+    public ngAfterViewInit () {
+        if (isPlatformBrowser(this.platformId)) {
             if (this.hasCompatibleBrowser()) {
                 this.registerIntersectionObserver();
                 if (this._intersectionObserver && this._element.nativeElement) {
                     this._intersectionObserver.observe(<Element>(this._element.nativeElement));
                 }
             } else {
-                if (this.fallbackEnabled) {
+                if (this.fallbackEnabled === true) {
                     this.addScrollListeners();
                 } else {
                     this.load();


### PR DESCRIPTION
Adding 

- Added `fallbackEnabled` flag to optionally turn off scroll position listeners for browsers that do not support IntersectionObserver API.
- Move scroll/intersection registration logic to OnInit