### PR TITLE
Specify whether to remove listeners after load

### DIFF
--- a/src/defer-load.directive.ts
+++ b/src/defer-load.directive.ts
@@ -10,6 +10,7 @@ export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
 
     @Input() public preRender: boolean = true;
     @Input() public fallbackEnabled: boolean = true;
+    @Input() public removeListenersAfterLoad: boolean = true;
     @Output() public deferLoad: EventEmitter<any> = new EventEmitter();
 
     private _intersectionObserver?: IntersectionObserver;
@@ -86,7 +87,9 @@ export class DeferLoadDirective implements OnInit, AfterViewInit, OnDestroy {
     }
 
     private load (): void {
-        this.removeListeners();
+        if (this.removeListenersAfterLoad) {
+            this.removeListeners();
+        }
         this.deferLoad.emit();
     }
 


### PR DESCRIPTION
Add an option to enable users specify whether to remove the listeners after the deferLoad event is emitted.